### PR TITLE
Scale by coefficient before rounding. Fixes probability dist.

### DIFF
--- a/sparkline/sparkline.py
+++ b/sparkline/sparkline.py
@@ -43,7 +43,7 @@ def sparkify(series, minimum=None, maximum=None):
         return min(max(n, minimum), maximum)
 
     def spark_for(n):
-        return spark_chars[int(round(clamp(n) - minimum) * coefficient)]
+        return spark_chars[int(round((clamp(n) - minimum) * coefficient))]
 
     return u''.join(spark_for(n) if _isan(n) else ' ' for n in series)
 


### PR DESCRIPTION
If sparkline is plotting a probability distribution, all
values will be in the range [0..1.0] and possibly all < 0.5.
Rounding before scaling can result in all values being rounded
to 0 in this case.  Scaling first corrects this problem.